### PR TITLE
zope.sqlalchemy 4.0 

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,19 +1,18 @@
 {% set name = "zope.sqlalchemy" %}
-{% set version = "2.0" %}
+{% set version = "4.0" %}
 
 package:
   name: {{ name|lower }}
   version: {{ version }}
 
 source:
-  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: cdf70cd57b8beb0ca9a81754abbf5c80ef0b53e8d8b2d894ac20bfc73870df12
+  url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/{{ name.replace(".", "_")}}-{{ version }}.tar.gz
+  sha256: d4aeb6d06aa7d0855d67fd3434b56674f01307c4cad50105c94bcfe391ee729d
 
 build:
   number: 0
-  script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation
-  # s390x missing transaction
-  skip: true  # [s390x or py<37]
+  script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation --ignore-installed --no-cache-dir -vvv
+  skip: true  # [py<37]
 
 requirements:
   host:
@@ -23,24 +22,58 @@ requirements:
     - wheel
   run:
     - python
-    - sqlalchemy >=1.1,!=1.4.0,!=1.4.1,!=1.4.2,!=1.4.3,!=1.4.4,!=1.4.5,!=1.4.6,<2
+    - packaging
+    - setuptools
+    - sqlalchemy >=1.1,!=1.4.0,!=1.4.1,!=1.4.2,!=1.4.3,!=1.4.4,!=1.4.5,!=1.4.6,!=2.0.32,!=2.0.33,!=2.0.34,!=2.0.35
     - transaction >=1.6.0
     - zope.interface >=3.6.0
 
+
+# FAILED src/zope/sqlalchemy/tests.py::RetryTests::testRetry - sqlalchemy.exc.OperationalError:
+# (sqlite3.OperationalError) no such table: test_users
+# [SQL: INSERT INTO test_users (id, firstname, lastname) VALUES (?, ?, ?)]
+# [parameters: (1, 'udo', 'juergens')]
+# (Background on this error at: https://sqlalche.me/e/20/e3q8)
+# FAILED src/zope/sqlalchemy/tests.py::RetryTests::testRetryThread - sqlalchemy.exc.OperationalError:
+# (sqlite3.OperationalError) no such table: test_users
+# [SQL: INSERT INTO test_users (id, firstname, lastname) VALUES (?, ?, ?)]
+# [parameters: (1, 'udo', 'juergens')]
+# (Background on this error at: https://sqlalche.me/e/20/e3q8)
+# FAILED src/zope/sqlalchemy/tests.py::test_suite - FileNotFoundError: [Errno 2]
+# No such file or directory: '$SRC_DIR/src/zope/sqlalchemy/README.rst'
+
+# Database setup environmets erorrs
+{% set SKIP_TEST_LIST = [
+    "testRetry",
+    "testRetryThread",
+    "test_suite"
+] %}
+
 test:
-  requires:
-    - pip
-  commands:
-    - pip check
+  source_files:
+    - src/zope/sqlalchemy/tests.py
   imports:
     - zope
     - zope.sqlalchemy
+    - zope.interface
+  requires:
+    - pip
+    - pytest
+    - sqlalchemy
+    - transaction >=1.6.0
+    - packaging
+  commands:
+    - pip check
+    - python -c "from importlib.metadata import version; assert(version('{{ name }}')=='{{ version }}')"
+    - pytest -ra -vv src/zope/sqlalchemy/tests.py -k "not slow and not ({{ SKIP_TEST_LIST | join(' or ') }})"
 
 about:
   home: https://pypi.org/pypi/zope.sqlalchemy
-  license: ZPL-2.1
+  license: BSD-3-Clause AND ZPL-2.1
   license_family: Other
-  license_file: LICENSE.txt
+  license_file:
+    - COPYRIGHT.txt
+    - LICENSE.txt
   summary: Minimal Zope/SQLAlchemy transaction integration
   description: |
     Unify the plethora of existing packages integrating SQLAlchemy with Zope's


### PR DESCRIPTION
zope.sqlalchemy 4.0 

**Destination channel:** Defaults

### Links

- [PKG-10446]
- dev_url:        https://github.com/zopefoundation/zope.sqlalchemy/tree/4.0
- conda_forge:    https://github.com/conda-forge/zope.sqlalchemy-feedstock
- pypi:           https://pypi.org/project/zope.sqlalchemy/4.0
- pypi inspector: https://inspector.pypi.io/project/zope.sqlalchemy/4.0

### Explanation of changes:

- 	Updated version from 2.0 → 4.0
- 	Simplified skip condition to [py<37] (removed s390x)
- 	Updated SQLAlchemy requirement
- 	Updated runtime deps: transaction >=1.6.0, zope.interface >=3.6.0, packaging, setuptools
- 	Added SKIP_TEST_LIST for DB-dependent tests (testRetry, testRetryThread, test_suite)
- 	Updated license to BSD-3-Clause AND ZPL-2.1 and included both COPYRIGHT.txt and LICENSE.txt


[PKG-10446]: https://anaconda.atlassian.net/browse/PKG-10446?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ